### PR TITLE
Update doivideo to use manual videojs setup.

### DIFF
--- a/doivideo/DESCRIPTION
+++ b/doivideo/DESCRIPTION
@@ -1,12 +1,17 @@
 Package: doivideo
 Title: Embed video from DOI using htmlwidget
-Version: 0.1.0
-Authors@R: 
+Version: 0.1.1
+Authors@R: c(
     person(given = "Thomas",
            family = "Morrell",
            role = c("aut", "cre"),
            email = "tmorrell@caltech.edu",
-           comment = c(ORCID = "0000-0001-9266-5146"))
+           comment = c(ORCID = "0000-0001-9266-5146")),
+    person(given = "Kian",
+           family = "Badie",
+           role = c("ctb"),
+           email = "kianbadie@yahoo.com")
+    )
 Description: Embed video player that takes a DOI.
 Imports:
     htmlwidgets

--- a/doivideo/inst/htmlwidgets/doivideo.js
+++ b/doivideo/inst/htmlwidgets/doivideo.js
@@ -29,14 +29,21 @@ HTMLWidgets.widget({
         }
         </style>
         <div class="video">
-        <video class="video-js vjs-default-skin vjs-big-play-centered" width="${width}" height="${height}" poster="${x.screenshot}" controls preload="auto" responsive=true id="my-video" data-setup='{"fluid": true}'>
-        <source src="${obj.media_url}" type='${obj.media_type}'>
+        <video class="video-js vjs-default-skin vjs-big-play-centered" width="${width}" height="${height}" id="my-video">
+        <source src="${obj.media_url}" type="${obj.media_type}">
         <p class="vjs-no-js">
           To view this video please enable JavaScript, and consider upgrading to a web browser that
           <a href="http://videojs.com/html5-video-support/" target="_blank">supports HTML5 video</a>
         </p>
       </video>
       </div>`;
+      videojs(document.querySelector(`#${el.id} video`), {
+        fluid: true,
+        controls: true,
+        preload: "auto",
+        responsive: true,
+        poster: `${x.screenshot}`
+      });
         });
       },
 


### PR DESCRIPTION
Fixes bug where videojs was not being applied to `<video>` elements or being applied to `<video>` elements in an unintended way. Also moved videojs options away from element attributes and implemented them as arguments to videojs setup. 

One unintended bug from this new change, however, is that videos do not seem to work on mobile phones and display an error message (screenshots added below). This seems like it is consistent with the current behavior, however, as when videojs was being applied to `<video>` elements it would also result in the same error. Now it seems the error is just 100% consistent now that videojs is being applied more consistently. After doing some research, I tried fiddling around with a simple server to enable byte-range requests, as directed in the [videojs documentation](https://docs.videojs.com/tutorial-troubleshooting.html#problems-when-hosting-media), but I was not able to resolve this bug, or find a definite reason why it was happening. Now that I think about it, maybe that is because the media is being hosted on a system other than my own, so enabling the byte-range requests was not being applied to the correct response. Any thoughts on this?

There was also an error being logged in the console `Unable to preventDefault inside passive event listener invocation` stemming from video navigation on mobile (using chrome dev tools), but that was also consistent with the current behavior. Looks like it could be something from touch screens from my very brief research. 

Other than that, I did not notice any glaring issues (I could not really determine any difference in load times)!

# Screenshots
## From live site
![IMG_2780](https://user-images.githubusercontent.com/18221058/97628939-a0750f80-19ea-11eb-93a9-6f1d2ecdd6e8.PNG)
## Running on my computer
![IMG_2781](https://user-images.githubusercontent.com/18221058/97628941-a10da600-19ea-11eb-834a-5058c477c158.PNG)